### PR TITLE
Add some basic information about Catena to the org readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,0 @@
-# Catena Tools
-
-Welcome to Catena Tools.

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,1 +1,20 @@
-# Welcome to Catena Tools 👋
+# Welcome to Catena Tools
+
+Built by game developers, for game developers to simplify your game's back end workflow.
+
+## Getting Started
+
+The following are key links to help direct you to get started.
+
+* [Documentation](https://docs.catenatools.com) - The primary source for information about Catena Tools.
+* [Catena Tools Core](https://github.com/catenatools/catena-tools-core) - The primary toolkit provided by Catena, where core game services are provided.
+* [Infrastructure Boilerplate](https://github.com/catenatools/infrastruture) - Code templates to stand up Catena and Game Servers on a variety of cloud platforms. 
+* [Launcher](https://github.com/catenatools/launcher) - A game launcher for distributing your game for internal and external playtests.
+*  [Catena Lyra Demo](https://github.com/catenatools/catena-lyra-demo) - An example game using Catena Tools and Unreal Engine.
+
+## Tutorials
+
+* [Up and Running Quickstart](https://docs.catenatools.com/quickstart-up-and-running.html) - Get your multiplayer game running quickly using Catena.
+
+*Note: Using Catena Tools requires a license agreement, please reach out to hello@catenatools.com for more info.*
+


### PR DESCRIPTION
Updates the org-wide readme to inclue some basic info ![image](https://github.com/CatenaTools/.github/assets/6408853/817fbd05-48a6-4651-97c4-c1e69e6e0853)
